### PR TITLE
Flush output when observing

### DIFF
--- a/aioairctrl/cli.py
+++ b/aioairctrl/cli.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import json
 import logging
+import sys
 
 from aioairctrl import CoAPClient
 
@@ -106,6 +107,7 @@ async def async_main() -> None:
                     print(json.dumps(status))
                 else:
                     print(status)
+                    sys.stdout.flush()
         elif args.command == "set":
             data = {}
             for e in args.values:


### PR DESCRIPTION
Hey @betaboon ,

thanks for your great work on this.
Found this repo via https://github.com/rgerganov/py-air-control/issues/93 and want to submit a small patch @Peter-J  has been working on.

Basically we should flush the output when observing so piping
the output into tools (like jq) works on each message which makes aioairctrl also great to use in some nodeJS HomeKit plugins I have integrated it with (but yet to publish).

