### PR TITLE
Flush output when observing 

### DIFF
--- a/aioairctrl/cli.py
+++ b/aioairctrl/cli.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import json
 import logging
+import sys
 
 from aioairctrl import CoAPClient
 
@@ -106,6 +107,7 @@ async def async_main() -> None:
                     print(json.dumps(status))
                 else:
                     print(status)
+                sys.stdout.flush()
         elif args.command == "set":
             data = {}
             for e in args.values:


### PR DESCRIPTION
Status-observe will work on console but not when the output is piped to something else. Flushing forces the output out of buffer so piping will work as expected.

see https://github.com/rgerganov/py-air-control/issues/93
and https://github.com/betaboon/aioairctrl/pull/4